### PR TITLE
feat: add support for setting mode

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           echo "test1" | tee file1.txt
           echo "test2" | tee file2.txt
+          echo "test3" | tee file3.txt
 
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -33,7 +34,13 @@ jobs:
           path: file2.txt
           key: test-cache-new-${{ github.run_id }}
 
-  cleanup:
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: file3.txt
+          key: test-cache-recent-${{ github.run_id }}
+
+  test-normal-mode:
+    name: Test normal mode (time-based)
     runs-on: ubuntu-latest
     needs: cache
     if: github.repository_owner == 'luxass'
@@ -50,5 +57,68 @@ jobs:
       - name: purge old caches (older than 10 seconds)
         uses: luxass/purge-action-cache@main
         with:
+          mode: normal
           debug: "true"
           max-age: 10
+          filter-key: last_accessed_at
+
+  test-normal-mode-created-at:
+    name: Test normal mode with created_at filter
+    runs-on: ubuntu-latest
+    needs: cache
+    if: github.repository_owner == 'luxass'
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: wait 5 seconds
+        run: sleep 5
+
+      - name: purge caches using created_at filter
+        uses: luxass/purge-action-cache@main
+        with:
+          mode: normal
+          debug: "true"
+          max-age: 5
+          filter-key: created_at
+
+  test-normal-mode-with-ref:
+    name: Test normal mode with specific ref
+    runs-on: ubuntu-latest
+    needs: cache
+    if: github.repository_owner == 'luxass'
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: purge old caches for current ref
+        uses: luxass/purge-action-cache@main
+        with:
+          mode: normal
+          debug: "true"
+          max-age: 3600
+          ref-key: ${{ github.ref }}
+
+  test-all-mode:
+    name: Test all mode
+    runs-on: ubuntu-latest
+    needs: [test-normal-mode, test-normal-mode-created-at, test-normal-mode-with-ref]
+    if: github.repository_owner == 'luxass'
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: purge all remaining caches
+        uses: luxass/purge-action-cache@main
+        with:
+          mode: all
+          debug: "true"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ GitHub Action for purging GitHub Actions Cache entries.
 
 ## Usage
 
-### Example workflow
+### Modes
+
+This action supports two modes:
+
+- **`normal`** (default): Purge caches older than a specified age, optionally targeting a specific ref
+- **`all`**: Purge all caches for the repository
+
+### Example workflows
+
+#### Normal mode - Purge old caches
 
 ```yaml
 name: Cleanup Actions Cache
@@ -19,13 +28,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Purge GitHub Actions Cache
-        uses: luxass/purge-action-cache@v0.1.0
+      - name: Purge old GitHub Actions Cache entries
+        uses: luxass/purge-action-cache@v0.2.0
         with:
-          max-age: 604800 # 7 days in seconds
-          filter-key: last_accessed_at # or created_at
+          mode: normal # default, can be omitted
+          max-age: 604800 # 7 days in seconds (default)
+          filter-key: last_accessed_at # or created_at (default: last_accessed_at)
           debug: true # optional, set to true for debug output
 ```
+
+#### Normal mode - Purge old caches for a specific ref
+
+```yaml
+- name: Purge old caches for feature branch
+  uses: luxass/purge-action-cache@v0.2.0
+  with:
+    mode: normal
+    ref-key: refs/heads/feature-branch
+    max-age: 86400 # 1 day in seconds
+    filter-key: created_at
+```
+
+#### All mode - Purge all caches
+
+```yaml
+- name: Purge all caches
+  uses: luxass/purge-action-cache@v0.2.0
+  with:
+    mode: all
+```
+
+## Inputs
+
+| Input        | Description                                                                                    | Required | Default               |
+| ------------ | ---------------------------------------------------------------------------------------------- | -------- | --------------------- |
+| `mode`       | Cache cleanup mode: `"normal"` or `"all"`                                                      | No       | `normal`              |
+| `max-age`    | Delete all caches older than this value in seconds (used with `normal` mode)                   | No       | `604800` (7 days)     |
+| `filter-key` | Filter caches by `"last_accessed_at"` or `"created_at"` (used with `normal` mode)              | No       | `last_accessed_at`    |
+| `ref-key`    | The branch or tag ref to target (used with `normal` mode). If not specified, uses `GITHUB_REF` | No       | `""`                  |
+| `debug`      | Output debug info                                                                              | No       | `false`               |
+| `token`      | GitHub token for API access                                                                    | No       | `${{ github.token }}` |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -10,19 +10,19 @@ inputs:
     description: 'Output debug info'
     default: "false"
   mode:
-    description: 'Cache cleanup mode: "age" (time-based), "ref" (branch or tag), or "all"'
+    description: 'Cache cleanup mode: "normal" (time-based with optional ref), or "all"'
     required: true
-    default: "age"
+    default: "normal"
   max-age:
-    description: 'Delete all caches older than this value in seconds (used with "age" mode)'
+    description: 'Delete all caches older than this value in seconds (used with "normal" mode)'
     required: false
     default: "604800"
   filter-key:
-    description: 'Filter caches by "last_accessed_at" or "created_at" (used with "age" mode)'
+    description: 'Filter caches by "last_accessed_at" or "created_at" (used with "normal" mode)'
     required: false
     default: "last_accessed_at"
-  ref:
-    description: 'The branch or tag ref to target (used with "ref" mode)'
+  ref-key:
+    description: 'The branch or tag ref to target. If not specified, uses GITHUB_REF (used with "normal" mode)'
     required: false
     default: ""
   token:
@@ -41,7 +41,7 @@ runs:
         INPUT_MODE: ${{ inputs.mode }}
         INPUT_MAX_AGE: ${{ inputs.max-age }}
         GH_TOKEN: ${{ inputs.token }}
-        INPUT_REF: ${{ inputs.ref }}
+        INPUT_REF_KEY: ${{ inputs.ref-key }}
         INPUT_FILTER_KEY: ${{ inputs.filter-key }}
       run: bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/run.sh"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,14 +9,22 @@ inputs:
   debug:
     description: 'Output debug info'
     default: "false"
-  max-age:
-    description: 'Delete all caches older than this value in seconds'
+  mode:
+    description: 'Cache cleanup mode: "age" (time-based), "ref" (branch or tag), or "all"'
     required: true
+    default: "age"
+  max-age:
+    description: 'Delete all caches older than this value in seconds (used with "age" mode)'
+    required: false
     default: "604800"
   filter-key:
-    description: 'Filter caches by "last_accessed_at" or "created_at"'
-    required: true
+    description: 'Filter caches by "last_accessed_at" or "created_at" (used with "age" mode)'
+    required: false
     default: "last_accessed_at"
+  ref:
+    description: 'The branch or tag ref to target (used with "ref" mode)'
+    required: false
+    default: ""
   token:
     description: Used to communicate with GitHub API. Since there's a default, this is typically not supplied by the user.
     default: ${{ github.token }}
@@ -30,8 +38,10 @@ runs:
     - id: purge-cache
       env:
         INPUT_DEBUG: ${{ inputs.debug }}
+        INPUT_MODE: ${{ inputs.mode }}
         INPUT_MAX_AGE: ${{ inputs.max-age }}
         GH_TOKEN: ${{ inputs.token }}
+        INPUT_REF: ${{ inputs.ref }}
         INPUT_FILTER_KEY: ${{ inputs.filter-key }}
       run: bash --noprofile --norc "${GITHUB_ACTION_PATH:?}/run.sh"
       shell: bash

--- a/run.sh
+++ b/run.sh
@@ -11,16 +11,13 @@ source "${SCRIPT_DIR}/utils.sh"
 ensure_requirements
 
 # Verify that `mode` is valid
-MODE="${INPUT_MODE:-age}"
+MODE="${INPUT_MODE:-normal}"
 
 ensure_options
 
 case "${MODE}" in
-  "age")
+  "normal")
     purge_by_age
-    ;;
-  "ref")
-    purge_by_age "${INPUT_REF}"
     ;;
   "all")
     purge_all

--- a/run.sh
+++ b/run.sh
@@ -7,80 +7,25 @@ IFS=$'\n\t'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/utils.sh"
 
-# check for jq
-check_jq
+# check for requirements
+ensure_requirements
 
-# check for gh
-check_gh
+# Verify that `mode` is valid
+MODE="${INPUT_MODE:-age}"
 
-# verify that filter key option is valid
-if [[ ! "${INPUT_FILTER_KEY:-}" =~ ^(created_at|last_accessed_at)$ ]]; then
-  bail "Invalid filter key option: ${INPUT_FILTER_KEY:-}. Valid options are: created_at, last_accessed_at."
-fi
+ensure_options
 
-if ! [[ "${INPUT_MAX_AGE:-604800}" =~ ^[0-9]+$ ]]; then
-  bail "Invalid INPUT_MAX_AGE value: '${INPUT_MAX_AGE:-604800}'. Please provide a valid number of seconds."
-fi
-
-
-MAX_DATE=$(( $(date +%s) - INPUT_MAX_AGE ))
-
-info "Purging caches older than ${INPUT_MAX_AGE} seconds (max date: ${MAX_DATE})."
-
-ALL_CACHE_ENTRIES=$(gh cache list \
-    --repo "${GITHUB_REPOSITORY:-}" \
-    --ref "${GITHUB_REF:-}" \
-    --limit "100" \
-    --json='createdAt,id,key,lastAccessedAt,ref,sizeInBytes,version')
-
-
-# Filter based on the filter key option
-case "${INPUT_FILTER_KEY:-last_accessed_at}" in
-  "created_at")
-    JQ_FILTER='.[] | select((.createdAt | .[0:19] +"Z" | fromdateiso8601) < '${MAX_DATE}')'
+case "${MODE}" in
+  "age")
+    purge_by_age
     ;;
-  "last_accessed_at")
-    JQ_FILTER='.[] | select((.lastAccessedAt | .[0:19] +"Z" | fromdateiso8601) < '${MAX_DATE}')'
+  "ref")
+    purge_by_age "${INPUT_REF}"
+    ;;
+  "all")
+    purge_all
+    ;;
+  *)
+    bail "Unsupported mode: ${MODE}"
     ;;
 esac
-
-info "Filtering cache entries older than ${INPUT_MAX_AGE} seconds using filter key: ${INPUT_FILTER_KEY:-last_accessed_at}"
-
-CACHE_ENTRIES=$(echo "${ALL_CACHE_ENTRIES}" | jq "${JQ_FILTER} | {
-  id: .id,
-  key: .key,
-  created_at: .createdAt,
-  last_accessed_at: .lastAccessedAt,
-  size_in_bytes: .sizeInBytes,
-  ref: .ref,
-  version: .version
-}")
-
-
-
-# print length of cache entries
-ALL_CACHE_COUNT=$(echo "${ALL_CACHE_ENTRIES}" | jq -s '.[] | length')
-CACHE_COUNT=$(echo "${CACHE_ENTRIES}" | jq -s length)
-info "Found ${ALL_CACHE_COUNT} total cache entries, ${CACHE_COUNT} of which are older than ${INPUT_MAX_AGE} seconds."
-
-# if no cache entries found, exit
-if [[ ${CACHE_COUNT} -eq 0 ]]; then
-  info "No cache entries to purge."
-  exit 0
-fi
-
-debug "Cache entries to purge:"
-echo "${CACHE_ENTRIES}" | jq -c '.' | while IFS= read -r ENTRY; do
-  debug "cache entry: $(echo "${ENTRY}" | jq -r '"key=\(.key), id=\(.id), size=\(.size_in_bytes) bytes, created=\(.created_at), last_accessed=\(.last_accessed_at)"')"
-done
-
-# loop through cache entries and purge them
-echo "${CACHE_ENTRIES}" | jq -c '.' | while IFS= read -r ENTRY; do
-  CACHE_KEY=$(echo "${ENTRY}" | jq -r '.key')
-
-  debug "purging cache entry key=(${CACHE_KEY}), id=($(echo "${ENTRY}" | jq -r '.id'))"
-
-  if ! gh cache delete "${CACHE_KEY}" --repo "${GITHUB_REPOSITORY:-}"; then
-    bail "Failed to purge cache entry with key: ${CACHE_KEY}"
-  fi
-done

--- a/utils.sh
+++ b/utils.sh
@@ -40,3 +40,112 @@ debug() {
     printf >&2 'debug: %s\n' "$*"
   fi
 }
+
+ensure_requirements() {
+  check_jq
+  check_gh
+}
+
+ensure_options() {
+  if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+    bail "GITHUB_REPOSITORY is not set. This action must be run in a GitHub Actions environment."
+  fi
+
+  # If mode is `ref`, ensure INPUT_REF is set
+  if [[ "${MODE}" == "ref" ]]; then
+    if [[ -z "${INPUT_REF:-}" ]]; then
+      bail "INPUT_REF must be set when mode is 'ref'."
+    fi
+  fi
+
+
+
+  # If mode is `age`
+  if [[ "${MODE}" == "age" ]]; then
+    # Ensure that INPUT_MAX_AGE is a valid number
+    if ! [[ "${INPUT_MAX_AGE:-604800}" =~ ^[0-9]+$ ]]; then
+      bail "Invalid INPUT_MAX_AGE value: '${INPUT_MAX_AGE:-604800}'. Please provide a valid number of seconds."
+    fi
+
+    # Ensure that INPUT_FILTER_KEY is valid
+    if ! [[ "${INPUT_FILTER_KEY:-}" =~ ^(created_at|last_accessed_at)$ ]]; then
+      bail "Invalid filter key option: ${INPUT_FILTER_KEY:-}. Valid options are: created_at, last_accessed_at."
+    fi
+  fi
+}
+
+purge_by_age() {
+  local max_age="${INPUT_MAX_AGE:-604800}"
+  local filter_key="${INPUT_FILTER_KEY:-last_accessed_at}"
+  local ref="${1:-${GITHUB_REF:-}}"
+
+  local max_date=$(( $(date +%s) - max_age ))
+
+  info "Purging caches older than ${max_age} seconds (max date: ${max_date})."
+
+  local all_cache_entries=$(gh cache list \
+      --repo "${GITHUB_REPOSITORY:-}" \
+      --ref "${ref}" \
+      --limit "100" \
+      --json='createdAt,id,key,lastAccessedAt,ref,sizeInBytes,version')
+
+  # Filter based on the filter key option
+  local jq_filter
+  case "${filter_key}" in
+    "created_at")
+      jq_filter='.[] | select((.createdAt | .[0:19] +"Z" | fromdateiso8601) < '${max_date}')'
+      ;;
+    "last_accessed_at")
+      jq_filter='.[] | select((.lastAccessedAt | .[0:19] +"Z" | fromdateiso8601) < '${max_date}')'
+      ;;
+  esac
+
+  info "Filtering cache entries older than ${max_age} seconds using filter key: ${filter_key}"
+
+  local cache_entries=$(echo "${all_cache_entries}" | jq "${jq_filter} | {
+    id: .id,
+    key: .key,
+    created_at: .createdAt,
+    last_accessed_at: .lastAccessedAt,
+    size_in_bytes: .sizeInBytes,
+    ref: .ref,
+    version: .version
+  }")
+
+  # print length of cache entries
+  local all_cache_count=$(echo "${all_cache_entries}" | jq -s '.[] | length')
+  local cache_count=$(echo "${cache_entries}" | jq -s length)
+  info "Found ${all_cache_count} total cache entries, ${cache_count} of which are older than ${max_age} seconds."
+
+  # if no cache entries found, exit
+  if [[ ${cache_count} -eq 0 ]]; then
+    info "No cache entries to purge."
+    return 0
+  fi
+
+  debug "Cache entries to purge:"
+  echo "${cache_entries}" | jq -c '.' | while IFS= read -r ENTRY; do
+    debug "cache entry: $(echo "${ENTRY}" | jq -r '"key=\(.key), id=\(.id), size=\(.size_in_bytes) bytes, created=\(.created_at), last_accessed=\(.last_accessed_at)"')"
+  done
+
+  # loop through cache entries and purge them
+  echo "${cache_entries}" | jq -c '.' | while IFS= read -r ENTRY; do
+    local cache_key=$(echo "${ENTRY}" | jq -r '.key')
+
+    debug "purging cache entry key=(${cache_key}), id=($(echo "${ENTRY}" | jq -r '.id'))"
+
+    if ! gh cache delete "${cache_key}" --repo "${GITHUB_REPOSITORY:-}" --ref "${ref}"; then
+      bail "Failed to purge cache entry with key: ${cache_key}"
+    fi
+  done
+}
+
+purge_all() {
+  info "Purging all caches using 'gh cache delete --all'."
+
+  if ! gh cache delete --all --repo "${GITHUB_REPOSITORY:-}"; then
+    bail "Failed to purge all cache entries"
+  fi
+
+  info "Successfully purged all cache entries."
+}


### PR DESCRIPTION
This PR adds a new mode `normal` and `all`.

The new `all` mode will clean all caches across all refs.

The other mode `normal` is similar to before, but not it supports a new --ref-key which will allow it to set a specific ref to delete for. This was defaulting to `GITHUB_REF` before.

If the `ref-key` isn't set it will still default to `GITHUB_REF`, but now you have the option to set it yourself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two cache cleanup modes: "normal" for time-based purging and "all" to purge all caches.
  * New optional input to target specific refs (branches/tags) for cleanup.
  * Enhanced filtering with multiple key options (created_at and last_accessed_at).
  * Made max-age and filter-key optional inputs.

* **Documentation**
  * Updated with comprehensive inputs table, modes explanation, and multiple workflow examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->